### PR TITLE
fixed unbound filename variable

### DIFF
--- a/publish.js
+++ b/publish.js
@@ -705,6 +705,7 @@ exports.publish = function(taffyData, opts, tutorials) {
         var tutorialData = {
             title: title,
             header: tutorial.title,
+			filename: filename,
             content: tutorial.parse(),
             children: tutorial.children
         };

--- a/publish.js
+++ b/publish.js
@@ -705,7 +705,7 @@ exports.publish = function(taffyData, opts, tutorials) {
         var tutorialData = {
             title: title,
             header: tutorial.title,
-			filename: filename,
+            filename: filename,
             content: tutorial.parse(),
             children: tutorial.children
         };


### PR DESCRIPTION
Hi Vinh,

layout.tmpl uses an unbound variable named filename. This is fixed by adding a filename member to the tutorialData object in publish.js. I used [this SO post](http://stackoverflow.com/questions/26531651/jaguarjs-jsdoc-fails-with-referenceerror-when-using-tutorials) to fix it—would you please merge this in?

Thanks,
Ryan
